### PR TITLE
Use GDocs sharing URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
 <body>
     <h1>Pisano's BatMUD Stuff</h1>
     <ul>
-        <li><a href="http://www.bat.org/u/Ual">BatMUD Ship Buying Guide</a></li>
-        <li><a href="http://www.bat.org/u/UZ_">Batclient FAQ and Best Practices</a></li>
-        <li><a href="https://docs.google.com/spreadsheets/d/1BxNHqaEub3xe1Wn7osZ6onQa2GxbUGT30MAGliYVIBw/edit#gid=0">Fulgurite Bead Bracelets</a></li>
+        <li><a href="https://docs.google.com/document/d/1S3UwTMyUphkewQSPuqjCmEv7ZjIMMZVAD7LyTkVhkZQ/edit?usp=sharing">BatMUD Ship Buying Guide</a></li>
+        <li><a href="https://docs.google.com/document/d/1bIMozRrQlpWx2d0y4PEcdstuE-Dz8wIAxgJ-7RuBvYc/edit?usp=sharing">Batclient FAQ and Best Practices</a></li>
+        <li><a href="https://docs.google.com/spreadsheets/d/1BxNHqaEub3xe1Wn7osZ6onQa2GxbUGT30MAGliYVIBw/edit?usp=sharing">Fulgurite Bead Bracelets</a></li>
     </ul>
 </body>
 


### PR DESCRIPTION
Update the links to the proper Google Docs sharing URLs.